### PR TITLE
Use versions from Django's release cycle.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django>=5.2,<5.3
+Django>=5.2,<6.0
 dj-database-url==2.3
 psycopg[binary]>=3.2,<3.3
 gunicorn>=23


### PR DESCRIPTION
Django 5.3 will never be released because the Django's release cycle is A.0, A.1, A.2:

https://docs.djangoproject.com/en/stable/internals/release-process